### PR TITLE
Inliner: Optional parameters for `load_data()`

### DIFF
--- a/crunch/inline.py
+++ b/crunch/inline.py
@@ -41,9 +41,9 @@ class _Inline:
             command.download_no_data_available()
             raise click.Abort()
 
-        x_train = utils.read(x_train_path, **kwargs)
-        y_train = utils.read(y_train_path, **kwargs)
-        x_test = utils.read(x_test_path, **kwargs)
+        x_train = utils.read(x_train_path, kwargs)
+        y_train = utils.read(y_train_path, kwargs)
+        x_test = utils.read(x_test_path, kwargs)
 
         return x_train, y_train, x_test
 

--- a/crunch/inline.py
+++ b/crunch/inline.py
@@ -41,9 +41,9 @@ class _Inline:
             command.download_no_data_available()
             raise click.Abort()
 
-        x_train = utils.read(x_train_path, kwargs)
-        y_train = utils.read(y_train_path, kwargs)
-        x_test = utils.read(x_test_path, kwargs)
+        x_train = utils.read(x_train_path, **kwargs)
+        y_train = utils.read(y_train_path, **kwargs)
+        x_test = utils.read(x_test_path, **kwargs)
 
         return x_train, y_train, x_test
 

--- a/crunch/inline.py
+++ b/crunch/inline.py
@@ -24,7 +24,7 @@ class _Inline:
 
         print(f"loaded inline runner with module: {module}")
 
-    def load_data(self) -> typing.Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
+    def load_data(self, **kwargs) -> typing.Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
         try:
             (
                 _, # embargo
@@ -41,9 +41,9 @@ class _Inline:
             command.download_no_data_available()
             raise click.Abort()
 
-        x_train = utils.read(x_train_path)
-        y_train = utils.read(y_train_path)
-        x_test = utils.read(x_test_path)
+        x_train = utils.read(x_train_path, **kwargs)
+        y_train = utils.read(y_train_path, **kwargs)
+        x_test = utils.read(x_test_path, **kwargs)
 
         return x_train, y_train, x_test
 

--- a/crunch/utils.py
+++ b/crunch/utils.py
@@ -148,12 +148,12 @@ def read(path: str, dataframe=True, **kwargs) -> typing.Union[pandas.DataFrame, 
     return joblib.load(path)
 
 
-def write(dataframe: typing.Union[pandas.DataFrame, typing.Any], path: str) -> None:
+def write(dataframe: typing.Union[pandas.DataFrame, typing.Any], path: str, **kwargs) -> None:
     if isinstance(dataframe, pandas.DataFrame):
         if path.endswith(".parquet"):
-            dataframe.to_parquet(path)
+            dataframe.to_parquet(path, **kwargs)
         else:
-            dataframe.to_csv(path)
+            dataframe.to_csv(path, **kwargs)
     else:
         joblib.dump(dataframe, path)
 

--- a/crunch/utils.py
+++ b/crunch/utils.py
@@ -142,8 +142,8 @@ def read_token():
 def read(path: str, dataframe=True, **kwargs) -> typing.Union[pandas.DataFrame, typing.Any]:
     if dataframe:
         if path.endswith(".parquet"):
-            return pandas.read_parquet(path, **kwargs)
-        return pandas.read_csv(path, **kwargs)
+            return pandas.read_parquet(path, kwargs)
+        return pandas.read_csv(path, kwargs)
 
     return joblib.load(path)
 

--- a/crunch/utils.py
+++ b/crunch/utils.py
@@ -139,11 +139,11 @@ def read_token():
     return _read_crunchdao_file(constants.TOKEN_FILE)
 
 
-def read(path: str, dataframe=True) -> typing.Union[pandas.DataFrame, typing.Any]:
+def read(path: str, dataframe=True, **kwargs) -> typing.Union[pandas.DataFrame, typing.Any]:
     if dataframe:
         if path.endswith(".parquet"):
-            return pandas.read_parquet(path)
-        return pandas.read_csv(path)
+            return pandas.read_parquet(path, **kwargs)
+        return pandas.read_csv(path, **kwargs)
 
     return joblib.load(path)
 

--- a/crunch/utils.py
+++ b/crunch/utils.py
@@ -142,8 +142,8 @@ def read_token():
 def read(path: str, dataframe=True, **kwargs) -> typing.Union[pandas.DataFrame, typing.Any]:
     if dataframe:
         if path.endswith(".parquet"):
-            return pandas.read_parquet(path, kwargs)
-        return pandas.read_csv(path, kwargs)
+            return pandas.read_parquet(path, **kwargs)
+        return pandas.read_csv(path, **kwargs)
 
     return joblib.load(path)
 


### PR DESCRIPTION
Allow the use of optional parameters for  pandas`read_parquet` and `read_csv`