### PR TITLE
feat(orthogonalization): auto retry

### DIFF
--- a/crunch/__version__.py
+++ b/crunch/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'crunch-cli'
 __description__ = 'crunch-cli - CLI of the CrunchDAO Platform'
-__version__ = '3.2.1'
+__version__ = '3.3.0'
 __author__ = 'Enzo CACERES'
 __author_email__ = 'enzo.caceres@crunchdao.com'
 __url__ = 'https://github.com/crunchdao/crunch-cli'


### PR DESCRIPTION
Some people were complaining about some API calls crashing their pipeline in the middle of the night.
As random networking failure happen, there is not much we can do to prevent it. So retrying is the safest bet.

## Feature

- orthogonalization: retry up to 3 time if a `ConnectionError` happen via the API.