### PR TITLE
feat(monkey-patch): trigger at python's start

### DIFF
--- a/crunch-monkeypatch.pth
+++ b/crunch-monkeypatch.pth
@@ -1,0 +1,1 @@
+import os, sys; exec('try: import crunch.monkey_patches; crunch.monkey_patches.apply_all()\nexcept ImportError as error: print("crunch: could not auto monkey patch:", error, file=sys.stderr)') if os.environ.get("CRUNCH_AUTO_MONKEY_PATCH", "false").lower() == "true" else None

--- a/crunch/__version__.py
+++ b/crunch/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'crunch-cli'
 __description__ = 'crunch-cli - CLI of the CrunchDAO Platform'
-__version__ = '3.6.0'
+__version__ = '3.7.0'
 __author__ = 'Enzo CACERES'
 __author_email__ = 'enzo.caceres@crunchdao.com'
 __url__ = 'https://github.com/crunchdao/crunch-cli'

--- a/crunch/monkey_patches.py
+++ b/crunch/monkey_patches.py
@@ -21,6 +21,7 @@ def apply_all():
     display_add()
     catboost_info_directory()
     logging_file_handler()
+    pycaret_internal_logging()
 
     _APPLIED = True
 
@@ -130,3 +131,12 @@ def logging_file_handler():
         original(self, filename, *args, **kwargs)
 
     logging.FileHandler.__init__ = patched
+
+
+def pycaret_internal_logging():
+    try:
+        import pycaret.internal.logging
+    except ModuleNotFoundError:
+        return
+    
+    pycaret.internal.logging.LOGGER = pycaret.internal.logging.create_logger("/dev/stdout")

--- a/crunch/monkey_patches.py
+++ b/crunch/monkey_patches.py
@@ -29,7 +29,8 @@ def io_no_tty():
     import sys
 
     for io in [sys.stdin, sys.stdout, sys.stderr]:
-        io.isatty = lambda: False
+        if io:
+            io.isatty = lambda: False
 
 
 def tqdm_display():

--- a/crunch/monkey_patches.py
+++ b/crunch/monkey_patches.py
@@ -5,7 +5,15 @@ import logging
 import sys
 
 
+_APPLIED = False
+
+
 def apply_all():
+    global _APPLIED
+
+    if _APPLIED:
+        return
+
     io_no_tty()
     tqdm_display()
     pathlib_str_functions()
@@ -13,6 +21,8 @@ def apply_all():
     display_add()
     catboost_info_directory()
     logging_file_handler()
+
+    _APPLIED = True
 
 
 def io_no_tty():

--- a/crunch/runner/cloud.py
+++ b/crunch/runner/cloud.py
@@ -456,7 +456,10 @@ class CloudRunner(Runner):
                         "-m", "crunch", "runner", "cloud-executor",
                         *args
                     ],
-                    self.venv_env
+                    {
+                        **self.venv_env,
+                        "CRUNCH_AUTO_MONKEY_PATCH": "true",
+                    }
                 )
             except SystemExit:
                 self.report_trace(moon)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ with open(os.path.join(here, package, '__version__.py')) as f:
 
 with open('requirements/default.txt') as fd:
     requirements = fd.read().splitlines()
-requirements = []
 
 with open('README.md') as fd:
     readme = fd.read()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,24 @@
 #!/usr/bin/env python3
 
+import distutils.sysconfig
 import os
-from setuptools import setup, find_packages
+import sys
+
+from setuptools import find_packages, setup
 
 package = "crunch"
+
+
+def find_pth_directory():
+    """
+    see https://github.com/xolox/python-coloredlogs/blob/65bdfe976ac0bf81e8c0bd9a98242b9d666b2859/setup.py#L64-L84
+    """
+
+    if 'bdist_wheel' in sys.argv:
+        return "/"
+
+    return os.path.relpath(distutils.sysconfig.get_python_lib(), sys.prefix)
+
 
 about = {}
 here = os.path.abspath(os.path.dirname(__file__))
@@ -12,6 +27,7 @@ with open(os.path.join(here, package, '__version__.py')) as f:
 
 with open('requirements/default.txt') as fd:
     requirements = fd.read().splitlines()
+requirements = []
 
 with open('README.md') as fd:
     readme = fd.read()
@@ -26,7 +42,9 @@ setup(
     author_email=about['__author_email__'],
     url=about['__url__'],
     packages=find_packages(),
-    include_package_data=True,
+    data_files=[
+        (find_pth_directory(), ['crunch-monkeypatch.pth']),
+    ],
     python_requires=">=3",
     install_requires=requirements,
     zip_safe=False,


### PR DESCRIPTION
[`loky`](https://pypi.org/project/loky/) is `fork`-ing then `execve`-ing a new Python process, skipping the monkey patches.
This cause some program to crash as they do not have the necessary patches to work in the runner.

The library now install a `.pth` file started at the initialization of Python, making sure the monkey patches are always applied.
They are only applied if `CRUNCH_AUTO_MONKEY_PATCH` envvar is set to `true`.

## Features

- setup: include a pth file to apply monkey patches before any user script
- monkey-patch/pycaret: redirect logging to stdout
- cloud runner: start executor with `CRUNCH_AUTO_MONKEY_PATCH=true`

## Fixes

- monkey-patch/io: check for null stream