### PR TITLE
feat: multiple target support

### DIFF
--- a/crunch/__init__.py
+++ b/crunch/__init__.py
@@ -8,4 +8,4 @@ your work to the crunchdao platform easily!
 from . import api, checker, orthogonalization, scoring
 from .inline import load as load_notebook
 from .orthogonalization import run as alpha_score
-from .runner import is_inside as is_inside_runner
+from .runner import is_inside as is_inside_runner, Columns

--- a/crunch/__version__.py
+++ b/crunch/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'crunch-cli'
 __description__ = 'crunch-cli - CLI of the CrunchDAO Platform'
-__version__ = '3.9.3'
+__version__ = '3.10.0'
 __author__ = 'Enzo CACERES'
 __author_email__ = 'enzo.caceres@crunchdao.com'
 __url__ = 'https://github.com/crunchdao/crunch-cli'

--- a/crunch/api/client.py
+++ b/crunch/api/client.py
@@ -27,6 +27,7 @@ from .domain.run import RunEndpointMixin
 from .domain.runner import RunnerRun, RunnerRunEndpointMixin
 from .domain.score import ScoreEndpointMixin
 from .domain.submission import SubmissionEndpointMixin
+from .domain.target import TargetEndpointMixin
 from .domain.user import UserCollection, UserEndpointMixin
 from .errors import convert_error
 
@@ -48,6 +49,7 @@ class EndpointClient(
     RunnerRunEndpointMixin,
     ScoreEndpointMixin,
     SubmissionEndpointMixin,
+    TargetEndpointMixin,
     UserEndpointMixin,
 ):
 

--- a/crunch/api/domain/__init__.py
+++ b/crunch/api/domain/__init__.py
@@ -12,6 +12,7 @@ from .crunch import Crunch
 from .data_release import (
     DataRelease,
     ColumnNames,
+    TargetColumnNames,
     DataReleaseTargetResolution,
     DataReleaseSplit,
     DataReleaseSplitGroup,
@@ -49,4 +50,5 @@ from .run import Run
 from .runner import RunnerRun
 from .score import Score
 from .submission import Submission
+from .target import Target
 from .user import User

--- a/crunch/api/domain/competition.py
+++ b/crunch/api/domain/competition.py
@@ -49,6 +49,16 @@ class Competition(Model):
         )
 
     @property
+    def metrics(self):
+        from .metric import MetricCollection
+
+        return MetricCollection(
+            competition=self,
+            target=None,
+            client=self._client
+        )
+
+    @property
     def targets(self):
         from .target import TargetCollection
 

--- a/crunch/api/domain/competition.py
+++ b/crunch/api/domain/competition.py
@@ -49,10 +49,10 @@ class Competition(Model):
         )
 
     @property
-    def metrics(self):
-        from .metric import MetricCollection
+    def targets(self):
+        from .target import TargetCollection
 
-        return MetricCollection(
+        return TargetCollection(
             competition=self,
             client=self._client
         )

--- a/crunch/api/domain/data_release.py
+++ b/crunch/api/domain/data_release.py
@@ -182,12 +182,36 @@ class DataRelease(Model):
     undefined=dataclasses_json.Undefined.EXCLUDE
 )
 @dataclasses.dataclass(frozen=True)
+class TargetColumnNames:
+
+    input: str
+    output: str
+
+
+@dataclasses_json.dataclass_json(
+    letter_case=dataclasses_json.LetterCase.CAMEL,
+    undefined=dataclasses_json.Undefined.EXCLUDE
+)
+@dataclasses.dataclass(frozen=True)
 class ColumnNames:
 
     id: str
     moon: str
-    target: str
-    prediction: str
+    targets: typing.Dict[str, TargetColumnNames]
+
+    @property
+    def inputs(self):
+        return [
+            target_column_names.input
+            for target_column_names in self.targets.values()
+        ]
+
+    @property
+    def outputs(self):
+        return [
+            target_column_names.output
+            for target_column_names in self.targets.values()
+        ]
 
 
 class DataReleaseCollection(Collection):

--- a/crunch/api/domain/data_release.py
+++ b/crunch/api/domain/data_release.py
@@ -87,7 +87,7 @@ class DataReleaseSplit:
     key: typing.Union[str, int]
     group: DataReleaseSplitGroup
     reduced: typing.Optional[DataReleaseSplitReduced] = None
-    
+
     @staticmethod
     def from_dict_array(
         input: typing.List[dict]
@@ -197,7 +197,19 @@ class ColumnNames:
 
     id: str
     moon: str
-    targets: typing.Dict[str, TargetColumnNames]
+    targets: typing.OrderedDict[str, TargetColumnNames]
+
+    @property
+    def first_target_name(self):
+        return next(iter(self.targets.keys()), None)
+
+    @property
+    def first_target(self):
+        key = self.first_target_name
+        if key is None:
+            return None
+
+        return self.targets[key]
 
     @property
     def inputs(self):

--- a/crunch/api/domain/metric.py
+++ b/crunch/api/domain/metric.py
@@ -119,7 +119,7 @@ class MetricCollection(Collection):
         return self.prepare_models(
             self._client.api.list_metrics(
                 self.competition.id,
-                self.target.name,
+                self.target.name if self.target else None,
             )
         )
 
@@ -151,9 +151,13 @@ class MetricEndpointMixin:
         competition_identifier,
         target_name,
     ):
+        url = (
+            f"/v1/competitions/{competition_identifier}/targets/{target_name}/metrics"
+            if target_name is not None else
+            f"/v1/competitions/{competition_identifier}/metrics"
+        )
+
         return self._result(
-            self.get(
-                f"/v1/competitions/{competition_identifier}/targets/{target_name}/metrics"
-            ),
+            self.get(url),
             json=True
         )

--- a/crunch/api/domain/target.py
+++ b/crunch/api/domain/target.py
@@ -1,0 +1,111 @@
+import typing
+
+from ..resource import Collection, Model
+from .competition import Competition
+
+
+class Target(Model):
+
+    resource_identifier_attribute = "name"
+
+    def __init__(
+        self,
+        competition: Competition,
+        attrs=None,
+        client=None,
+        collection=None
+    ):
+        super().__init__(attrs, client, collection)
+
+        self._competition = competition
+
+    @property
+    def competition(self):
+        return self._competition
+
+    @property
+    def metrics(self):
+        from .metric import MetricCollection
+
+        return MetricCollection(
+            competition=self._competition,
+            target=self,
+            client=self._client
+        )
+
+    @property
+    def name(self) -> str:
+        return self._attrs["name"]
+
+    @property
+    def display_name(self) -> str:
+        return self._attrs["displayName"]
+
+
+class TargetCollection(Collection):
+
+    model = Target
+
+    def __init__(
+        self,
+        competition: Competition,
+        client=None
+    ):
+        super().__init__(client)
+
+        self.competition = competition
+
+    def __iter__(self) -> typing.Iterator[Target]:
+        return super().__iter__()
+
+    def get(
+        self,
+        name: str
+    ) -> Target:
+        return self.prepare_model(
+            self._client.api.get_target(
+                self.competition.id,
+                name
+            )
+        )
+
+    def list(
+        self
+    ) -> Target:
+        return self.prepare_models(
+            self._client.api.list_targets(
+                self.competition.id
+            )
+        )
+
+    def prepare_model(self, attrs):
+        return super().prepare_model(
+            attrs,
+            self.competition
+        )
+
+
+class TargetEndpointMixin:
+
+    def get_target(
+        self,
+        competition_identifier,
+        name
+    ):
+        return self._result(
+            self.get(
+                f"/v1/competitions/{competition_identifier}/targets/{name}"
+            ),
+            json=True
+        )
+
+    def list_targets(
+        self,
+        competition_identifier
+    ):
+        return self._result(
+            self.get(
+                f"/v1/competitions/{competition_identifier}/targets"
+            ),
+            json=True
+        )

--- a/crunch/checker/checker.py
+++ b/crunch/checker/checker.py
@@ -37,29 +37,32 @@ def _run_checks(
             logger.error(f"missing function - name={function_name.name}")
             continue
 
-        parameters = check.parameters
-        logger.info(f"check prediction - call={function.__name__}({parameters}) moon={moon}")
+        for _, target_column_names in column_names.targets.items():
+            parameters = check.parameters
+            prediction_column_name = target_column_names.output
 
-        try:
-            utils.smart_call(function, {
-                "prediction": prediction,
-                "example_prediction": example_prediction,
-                "id_column_name": column_names.id,
-                "moon_column_name": column_names.moon,
-                "prediction_column_name": column_names.prediction,
-                "column_names": column_names,
-                "competition_format": competition_format,
-                **parameters,
-            })
-        except CheckError as error:
-            if moon is None:
-                raise
+            logger.info(f"check prediction - call={function.__name__}({parameters}) moon={moon} prediction_column_name=`{prediction_column_name}`")
 
-            raise CheckError(f"{error} on {column_names.moon}={moon}") from error
-        except Exception as exception:
-            raise CheckError(
-                "failed to check"
-            ) from exception
+            try:
+                utils.smart_call(function, {
+                    "prediction": prediction,
+                    "example_prediction": example_prediction,
+                    "id_column_name": column_names.id,
+                    "moon_column_name": column_names.moon,
+                    "prediction_column_name": prediction_column_name,
+                    "column_names": column_names,
+                    "competition_format": competition_format,
+                    **parameters,
+                })
+            except CheckError as error:
+                if moon is None:
+                    raise
+
+                raise CheckError(f"{error} on {column_names.moon}={moon} column={prediction_column_name}") from error
+            except Exception as exception:
+                raise CheckError(
+                    "failed to check"
+                ) from exception
 
 
 def run_via_api(

--- a/crunch/checker/functions.py
+++ b/crunch/checker/functions.py
@@ -134,9 +134,9 @@ REGISTRY = {
     api.CheckFunction.COLUMNS_NAME: CheckFunctionDescriptor(columns_name, False),
     api.CheckFunction.NANS: CheckFunctionDescriptor(nans, False),
     api.CheckFunction.IDS: CheckFunctionDescriptor(ids, False),
+    api.CheckFunction.MOONS: CheckFunctionDescriptor(moons, False),
 
     api.CheckFunction.VALUES_BETWEEN: CheckFunctionDescriptor(values_between, True),
     api.CheckFunction.VALUES_ALLOWED: CheckFunctionDescriptor(values_allowed, True),
-    api.CheckFunction.MOONS: CheckFunctionDescriptor(moons, True),
     api.CheckFunction.CONSTANTS: CheckFunctionDescriptor(constants, True),
 }

--- a/crunch/checker/functions.py
+++ b/crunch/checker/functions.py
@@ -1,5 +1,7 @@
 import numpy
 import pandas
+import dataclasses
+import typing
 
 from .. import api
 
@@ -114,12 +116,27 @@ def constants(
         raise CheckError(f"Constant values")
 
 
+@dataclasses.dataclass()
+class CheckFunctionDescriptor:
+    """
+    column_based: Refer to the multiple target system where it is better to check on individual columns to help the user understand where the issue is.
+    """
+
+    callable: typing.Callable
+    column_based: bool = True
+
+    @property
+    def name(self):
+        return self.callable.__name__
+
+
 REGISTRY = {
-    api.CheckFunction.COLUMNS_NAME: columns_name,
-    api.CheckFunction.NANS: nans,
-    api.CheckFunction.VALUES_BETWEEN: values_between,
-    api.CheckFunction.VALUES_ALLOWED: values_allowed,
-    api.CheckFunction.MOONS: moons,
-    api.CheckFunction.IDS: ids,
-    api.CheckFunction.CONSTANTS: constants,
+    api.CheckFunction.COLUMNS_NAME: CheckFunctionDescriptor(columns_name, False),
+    api.CheckFunction.NANS: CheckFunctionDescriptor(nans, False),
+    api.CheckFunction.IDS: CheckFunctionDescriptor(ids, False),
+
+    api.CheckFunction.VALUES_BETWEEN: CheckFunctionDescriptor(values_between, True),
+    api.CheckFunction.VALUES_ALLOWED: CheckFunctionDescriptor(values_allowed, True),
+    api.CheckFunction.MOONS: CheckFunctionDescriptor(moons, True),
+    api.CheckFunction.CONSTANTS: CheckFunctionDescriptor(constants, True),
 }

--- a/crunch/cli.py
+++ b/crunch/cli.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import typing
 
 import click
 
@@ -477,8 +478,7 @@ def cloud(
 # ---
 @click.option("--id-column-name", required=True)
 @click.option("--moon-column-name", required=True)
-@click.option("--target-column-name", required=True)
-@click.option("--prediction-column-name", required=True)
+@click.option("--target", "targets", required=True, multiple=True, nargs=3)
 def cloud_executor(
     competition_name: str,
     competition_format: str,
@@ -493,8 +493,8 @@ def cloud_executor(
     model_directory_path: str,
     prediction_path: str,
     trace_path: str,
-    state_file: list,
-    ping_urls: list,
+    state_file: str,
+    ping_urls: typing.List[str],
     # ---
     train: bool,
     moon: int,
@@ -504,8 +504,7 @@ def cloud_executor(
     # ---
     id_column_name: str,
     moon_column_name: str,
-    target_column_name: str,
-    prediction_column_name: str,
+    targets: typing.List[typing.Tuple[str, str, str]],
 ):
     from .runner import is_inside
     if not is_inside:
@@ -542,8 +541,10 @@ def cloud_executor(
         api.ColumnNames(
             id_column_name,
             moon_column_name,
-            target_column_name,
-            prediction_column_name
+            {
+                target_name: api.TargetColumnNames(input, output)
+                for target_name, input, output in targets
+            }
         )
     )
 

--- a/crunch/cli.py
+++ b/crunch/cli.py
@@ -27,6 +27,50 @@ def cli(
     store.web_base_url = web_base_url
 
 
+
+@cli.command(help="Initialize an empty workspace directory.")
+@click.option("--token", "clone_token", required=True, help="Clone token to use.")
+@click.option("--no-data", is_flag=True, help="Do not download the data. (faster)")
+@click.option("--force", "-f", is_flag=True, help="Deleting the old directory (if any).")
+@click.option("--model-directory", "model_directory_path", default="resources", show_default=True, help="Directory where your model is stored.")
+@click.argument("competition-name", required=True)
+@click.argument("directory", default="{competitionName}")
+def init(
+    clone_token: str,
+    no_data: bool,
+    force: bool,
+    competition_name: str,
+    directory: str,
+    model_directory_path: str,
+):
+    directory = directory\
+        .replace("{competitionName}", competition_name)
+
+    directory = os.path.normpath(directory)
+
+    try:
+        command.init(
+            clone_token=clone_token,
+            competition_name=competition_name,
+            directory=directory,
+            model_directory=model_directory_path,
+            force=force,
+        )
+
+        if not no_data:
+            command.download(force=True)
+    except api.CrunchNotFoundException:
+        command.download_no_data_available()
+    except api.ApiException as error:
+        utils.exit_via(
+            error,
+            competition_name=competition_name
+        )
+
+    print("\n---")
+    print(f"Success! Your environment has been correctly initialized.")
+
+
 @cli.command(help="Setup a workspace directory with the latest submission of you code.")
 @click.option("--token", "clone_token", required=True, help="Clone token to use.")
 @click.option("--submission", "submission_number", required=False, type=int, help="Submission number to clone. (latest if not specified)")

--- a/crunch/cli.py
+++ b/crunch/cli.py
@@ -18,15 +18,23 @@ store.load_from_env()
 @click.option("--debug", envvar=constants.DEBUG_ENV_VAR, is_flag=True, help="Enable debug output.")
 @click.option("--api-base-url", envvar=constants.API_BASE_URL_ENV_VAR, default=constants.API_BASE_URL_DEFAULT, help="Set the API base url.")
 @click.option("--web-base-url", envvar=constants.WEB_BASE_URL_ENV_VAR, default=constants.WEB_BASE_URL_DEFAULT, help="Set the Web base url.")
+@click.option("--staging", is_flag=True, help="Connect to the staging environment.")
 def cli(
     debug: bool,
     api_base_url: str,
     web_base_url: str,
+    staging: bool,
 ):
     store.debug = debug
     store.api_base_url = api_base_url
     store.web_base_url = web_base_url
 
+    if staging:
+        print("environment: forcing staging urls")
+        print(f"environment: ignoring ${constants.API_BASE_URL_ENV_VAR} and ${constants.WEB_BASE_URL_ENV_VAR}")
+
+        store.api_base_url = constants.API_BASE_URL_STAGING
+        store.web_base_url = constants.WEB_BASE_URL_STAGING
 
 
 @cli.command(help="Initialize an empty workspace directory.")

--- a/crunch/command/__init__.py
+++ b/crunch/command/__init__.py
@@ -1,5 +1,6 @@
 from .convert import convert, convert_cells_to_file
 from .download import download, download_no_data_available
+from .init import init
 from .push import push
 from .quickstarter import quickstarter
 from .setup import setup

--- a/crunch/command/init.py
+++ b/crunch/command/init.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+
+import click
+
+from .. import api, constants, utils
+
+
+def _delete_tree_if_exists(path: str):
+    if os.path.exists(path):
+        print(f"delete {path}")
+        shutil.rmtree(path)
+
+
+def _check_if_already_exists(directory: str, force: bool):
+    if not os.path.exists(directory):
+        return False
+
+    if force:
+        return True
+    elif len(os.listdir(directory)):
+        print(f"{directory}: directory not empty (use --force to override)")
+        raise click.Abort()
+
+
+def init(
+    clone_token: str,
+    competition_name: str,
+    directory: str,
+    model_directory: str,
+    force: bool,
+):
+    should_delete = _check_if_already_exists(directory, force)
+
+    client = api.Client.from_env()
+    project_token = client.project_tokens.upgrade(clone_token)
+
+    dot_crunchdao_path = os.path.join(directory, constants.DOT_CRUNCHDAO_DIRECTORY)
+    if should_delete:
+        _delete_tree_if_exists(dot_crunchdao_path)
+
+    os.makedirs(dot_crunchdao_path, exist_ok=True)
+
+    plain = project_token.plain
+    user_id = project_token.project.user_id
+    project_info = utils.ProjectInfo(
+        competition_name,
+        user_id
+    )
+
+    utils.write_project_info(project_info, directory)
+    utils.write_token(plain, directory)
+
+    os.chdir(directory)
+    os.makedirs(model_directory, exist_ok=True)

--- a/crunch/command/setup.py
+++ b/crunch/command/setup.py
@@ -1,27 +1,6 @@
-import os
-import shutil
 import typing
 
-import click
-
-from .. import api, command, constants, utils
-
-
-def _delete_tree_if_exists(path: str):
-    if os.path.exists(path):
-        print(f"delete {path}")
-        shutil.rmtree(path)
-
-
-def _check_if_already_exists(directory: str, force: bool):
-    if not os.path.exists(directory):
-        return False
-
-    if force:
-        return True
-    elif len(os.listdir(directory)):
-        print(f"{directory}: directory not empty (use --force to override)")
-        raise click.Abort()
+from .. import api, command, utils
 
 
 def setup(
@@ -35,28 +14,13 @@ def setup(
     quickstarter_name: typing.Optional[str],
     show_notebook_quickstarters: bool,
 ):
-    should_delete = _check_if_already_exists(directory, force)
-
-    client = api.Client.from_env()
-    project_token = client.project_tokens.upgrade(clone_token)
-
-    dot_crunchdao_path = os.path.join(directory, constants.DOT_CRUNCHDAO_DIRECTORY)
-    if should_delete:
-        _delete_tree_if_exists(dot_crunchdao_path)
-
-    os.makedirs(dot_crunchdao_path, exist_ok=True)
-
-    plain = project_token.plain
-    user_id = project_token.project.user_id
-    project_info = utils.ProjectInfo(
+    command.init(
+        clone_token,
         competition_name,
-        user_id
+        directory,
+        model_directory,
+        force
     )
-
-    utils.write_project_info(project_info, directory)
-    utils.write_token(plain, directory)
-
-    os.chdir(directory)
     _, project = api.Client.from_project()
 
     try:
@@ -73,5 +37,3 @@ def setup(
             show_notebook_quickstarters,
             True,
         )
-
-    os.makedirs(model_directory, exist_ok=True)

--- a/crunch/constants.py
+++ b/crunch/constants.py
@@ -21,5 +21,7 @@ API_KEY_ENV_VAR = "CRUNCH_API_KEY"
 
 API_BASE_URL_ENV_VAR = "API_BASE_URL"
 API_BASE_URL_DEFAULT = "http://api.hub.crunchdao.com/"
+API_BASE_URL_STAGING = "http://api.hub.crunchdao.io/"
 WEB_BASE_URL_ENV_VAR = "WEB_BASE_URL"
 WEB_BASE_URL_DEFAULT = "https://hub.crunchdao.com/"
+WEB_BASE_URL_STAGING = "https://hub.crunchdao.io/"

--- a/crunch/ensure.py
+++ b/crunch/ensure.py
@@ -23,13 +23,14 @@ def return_infer(
     result,
     id_column_name: str,
     moon_column_name: str,
-    prediction_column_name: str
+    prediction_column_names: list
 ) -> pandas.DataFrame:
     is_dataframe(result, "prediction")
 
+    # TODO should not happen, but should we still use a set here?
     expected = {
         id_column_name,
-        prediction_column_name
+        *prediction_column_names
     }
 
     if moon_column_name is not None:

--- a/crunch/runner/__init__.py
+++ b/crunch/runner/__init__.py
@@ -1,3 +1,5 @@
 import os
 
+from .columns import Columns
+
 is_inside = os.getenv("CRUNCH_INSIDE_RUNNER", "false").lower() == "true"

--- a/crunch/runner/cloud.py
+++ b/crunch/runner/cloud.py
@@ -427,12 +427,22 @@ class CloudRunner(Runner):
                 "gpu": self.gpu,
                 # ---
                 "id-column-name": self.column_names.id,
-                "moon-column-name": self.column_names.moon or "",
-                "target-column-name": self.column_names.target or "",
-                "prediction-column-name": self.column_names.prediction,
+                "moon-column-name": self.column_names.moon,
+                "target": [
+                    (target_name, target_column_names.input, target_column_names.output)
+                    for target_name, target_column_names in self.column_names.targets.items()
+                ],
             }
 
+            # TODO move to a dedicated function
             args = []
+            def append_value(value: typing.Any):
+                if isinstance(value, tuple):
+                    for x in value:
+                        args.append(str(x))
+                else:
+                    args.append(str(value))
+
             for key, value in options.items():
                 if value is None:
                     continue
@@ -443,10 +453,10 @@ class CloudRunner(Runner):
                 if isinstance(value, list):
                     for item in value:
                         args.append(f"--{key}")
-                        args.append(str(item))
+                        append_value(item)
                 else:
                     args.append(f"--{key}")
-                    args.append(str(value))
+                    append_value(value)
 
             try:
                 self.do_bash(

--- a/crunch/runner/columns.py
+++ b/crunch/runner/columns.py
@@ -1,0 +1,64 @@
+import collections
+import typing
+
+
+STORAGE_PROPERTY = "_storage"
+
+
+def _get_storage(self: "Columns") -> typing.OrderedDict:
+    return object.__getattribute__(self, STORAGE_PROPERTY)
+
+
+class Columns:
+
+    def __init__(self, storage: typing.OrderedDict, _copy=True):
+        if _copy:
+            storage = collections.OrderedDict(storage)
+
+        object.__setattr__(self, STORAGE_PROPERTY, storage)
+
+    def __getitem__(self, key):
+        return _get_storage(self)[key]
+
+    def __getattribute__(self, key):
+        if key == STORAGE_PROPERTY:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+
+        return object.__getattribute__(self, key)
+
+    def __getattr__(self, key):
+        storage = _get_storage(self)
+        if key in storage:
+            return storage[key]
+
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+
+    def __setitem__(self, key, _):
+        raise AttributeError(f"Cannot set key '{key}' - object is immutable")
+
+    def __setattr__(self, key, _):
+        raise AttributeError(f"Cannot set attribute '{key}' - object is immutable")
+
+    def __iter__(self):
+        return iter(_get_storage(self).values())
+
+    def __repr__(self):
+        items = ', '.join(f"{k}: {v!r}" for k, v in _get_storage(self).items())
+        return "{" + str(items) + "}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.__repr__()})"
+
+    @staticmethod
+    def from_model(column_names: "api.ColumnNames"):
+        inputs = collections.OrderedDict()
+        outputs = collections.OrderedDict()
+
+        for key, value in column_names.targets.items():
+            inputs[key] = value.input
+            outputs[key] = value.output
+
+        return (
+            Columns(inputs, _copy=False),
+            Columns(outputs, _copy=False),
+        )

--- a/crunch/runner/local.py
+++ b/crunch/runner/local.py
@@ -8,7 +8,7 @@ import pandas
 
 from .. import (api, checker, command, constants, ensure, monkey_patches,
                 tester, utils)
-from .runner import Runner
+from .runner import Runner, Columns
 
 
 class LocalRunner(Runner):
@@ -119,11 +119,14 @@ class LocalRunner(Runner):
         x_test = utils.read(self.x_test_path, kwargs=self.read_kwargs)
         y_train = utils.read(self.y_train_path, kwargs=self.read_kwargs)
 
+        _, prediction_column_names = Columns.from_model(self.column_names)
+
         default_values = {
             "number_of_features": self.number_of_features,
             "model_directory_path": self.model_directory_path,
             "id_column_name": self.column_names.id,
-            "prediction_column_name": self.column_names.prediction,
+            "prediction_column_name": self.column_names.first_target.output,
+            "prediction_column_names": prediction_column_names,
             "column_names": self.column_names,
             "has_gpu": self.has_gpu,
             "has_trained": True,
@@ -159,13 +162,17 @@ class LocalRunner(Runner):
         moon: int,
         train: bool
     ) -> pandas.DataFrame:
+        target_column_names, prediction_column_names = Columns.from_model(self.column_names)
+
         default_values = {
             "number_of_features": self.number_of_features,
             "model_directory_path": self.model_directory_path,
             "id_column_name": self.column_names.id,
             "moon_column_name": self.column_names.moon,
-            "target_column_name": self.column_names.target,
-            "prediction_column_name": self.column_names.prediction,
+            "target_column_name": self.column_names.first_target.input,
+            "target_column_names": target_column_names,
+            "prediction_column_name": self.column_names.first_target.output,
+            "prediction_column_names": prediction_column_names,
             "column_names": self.column_names,
             "moon": moon,
             "current_moon": moon,
@@ -199,7 +206,7 @@ class LocalRunner(Runner):
                 prediction,
                 self.column_names.id,
                 self.column_names.moon,
-                self.column_names.prediction,
+                self.column_names.outputs,
             )
 
         return prediction

--- a/crunch/runner/local.py
+++ b/crunch/runner/local.py
@@ -236,7 +236,7 @@ class LocalRunner(Runner):
 
                 logging.warn(f"prediction is valid")
             except checker.CheckError as error:
-                if error.__cause__:
+                if not isinstance(error.__cause__, checker.CheckError):
                     logging.exception(
                         "check failed - message=`%s`",
                         error,

--- a/crunch/runner/runner.py
+++ b/crunch/runner/runner.py
@@ -1,71 +1,10 @@
 import abc
-import collections
 import typing
 
 import pandas
 
 from .. import api
-
-STORAGE_PROPERTY = "_storage"
-
-
-def _get_storage(self: "Columns") -> typing.OrderedDict:
-    return object.__getattribute__(self, STORAGE_PROPERTY)
-
-
-class Columns:
-
-    def __init__(self, storage: typing.OrderedDict, _copy=True):
-        if _copy:
-            storage = collections.OrderedDict(storage)
-
-        object.__setattr__(self, STORAGE_PROPERTY, storage)
-
-    def __getitem__(self, key):
-        return _get_storage(self)[key]
-
-    def __getattribute__(self, key):
-        if key == STORAGE_PROPERTY:
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
-
-        return object.__getattribute__(self, key)
-
-    def __getattr__(self, key):
-        storage = _get_storage(self)
-        if key in storage:
-            return storage[key]
-
-        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
-
-    def __setitem__(self, key, _):
-        raise AttributeError(f"Cannot set key '{key}' - object is immutable")
-
-    def __setattr__(self, key, _):
-        raise AttributeError(f"Cannot set attribute '{key}' - object is immutable")
-
-    def __iter__(self):
-        return iter(_get_storage(self).values())
-
-    def __repr__(self):
-        items = ', '.join(f"{k}: {v!r}" for k, v in _get_storage(self).items())
-        return "{" + str(items) + "}"
-
-    def __str__(self):
-        return f"{self.__class__.__name__}({self.__repr__()})"
-
-    @staticmethod
-    def from_model(column_names: "api.ColumnNames"):
-        inputs = collections.OrderedDict()
-        outputs = collections.OrderedDict()
-
-        for key, value in column_names.targets.items():
-            inputs[key] = value.input
-            outputs[key] = value.output
-
-        return (
-            Columns(inputs, _copy=False),
-            Columns(outputs, _copy=False),
-        )
+from .columns import Columns
 
 
 class Runner(abc.ABC):

--- a/crunch/runner/runner.py
+++ b/crunch/runner/runner.py
@@ -1,9 +1,71 @@
 import abc
+import collections
 import typing
 
 import pandas
 
 from .. import api
+
+STORAGE_PROPERTY = "_storage"
+
+
+def _get_storage(self: "Columns") -> typing.OrderedDict:
+    return object.__getattribute__(self, STORAGE_PROPERTY)
+
+
+class Columns:
+
+    def __init__(self, storage: typing.OrderedDict, _copy=True):
+        if _copy:
+            storage = collections.OrderedDict(storage)
+
+        object.__setattr__(self, STORAGE_PROPERTY, storage)
+
+    def __getitem__(self, key):
+        return _get_storage(self)[key]
+
+    def __getattribute__(self, key):
+        if key == STORAGE_PROPERTY:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+
+        return object.__getattribute__(self, key)
+
+    def __getattr__(self, key):
+        storage = _get_storage(self)
+        if key in storage:
+            return storage[key]
+
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+
+    def __setitem__(self, key, _):
+        raise AttributeError(f"Cannot set key '{key}' - object is immutable")
+
+    def __setattr__(self, key, _):
+        raise AttributeError(f"Cannot set attribute '{key}' - object is immutable")
+
+    def __iter__(self):
+        return iter(_get_storage(self).values())
+
+    def __repr__(self):
+        items = ', '.join(f"{k}: {v!r}" for k, v in _get_storage(self).items())
+        return "{" + str(items) + "}"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.__repr__()})"
+
+    @staticmethod
+    def from_model(column_names: "api.ColumnNames"):
+        inputs = collections.OrderedDict()
+        outputs = collections.OrderedDict()
+
+        for key, value in column_names.targets.items():
+            inputs[key] = value.input
+            outputs[key] = value.output
+
+        return (
+            Columns(inputs, _copy=False),
+            Columns(outputs, _copy=False),
+        )
 
 
 class Runner(abc.ABC):
@@ -58,7 +120,7 @@ class Runner(abc.ABC):
                 moon,
                 train,
             )
-            
+
             predictions.append(prediction)
 
         return pandas.concat(predictions)
@@ -74,7 +136,7 @@ class Runner(abc.ABC):
         train: bool
     ) -> pandas.DataFrame:
         ...
-    
+
     def setup(self):
         ...
 

--- a/crunch/scoring/_format/dag.py
+++ b/crunch/scoring/_format/dag.py
@@ -75,66 +75,74 @@ def process_prediction(
     prediction: pandas.DataFrame,
     column_names: api.ColumnNames,
 ):
-    prediction = prediction[[
-        column_names.id,
-        column_names.prediction
-    ]].copy()
+    # TODO support multiple target
+    for targe_column_names in column_names.targets.values():
+        prediction_column_name = targe_column_names.output
+        
+        prediction = prediction[[
+            column_names.id,
+            prediction_column_name
+        ]].copy()
 
-    # TODO too specific
-    id_column = prediction[column_names.id].str.split('_')
-    prediction[column_names.id] = id_column.str[:-2].str.join('_')
-    prediction[FROM_COLUMN_NAME] = id_column.str[-2]
-    prediction[TO_COLUMN_NAME] = id_column.str[-1]
+        # TODO too specific
+        id_column = prediction[column_names.id].str.split('_')
+        prediction[column_names.id] = id_column.str[:-2].str.join('_')
+        prediction[FROM_COLUMN_NAME] = id_column.str[-2]
+        prediction[TO_COLUMN_NAME] = id_column.str[-1]
 
-    dataframes: typing.List[pandas.DataFrame] = []
-    for key, group in prediction.groupby(column_names.id):
-        group = group.pivot(
-            index=FROM_COLUMN_NAME,
-            columns=TO_COLUMN_NAME,
-            values=column_names.prediction
-        )
+        dataframes: typing.List[pandas.DataFrame] = []
+        for key, group in prediction.groupby(column_names.id):
+            group = group.pivot(
+                index=FROM_COLUMN_NAME,
+                columns=TO_COLUMN_NAME,
+                values=prediction_column_name
+            )
 
-        graph = networkx.from_pandas_adjacency(group, create_using=networkx.DiGraph)
-        labels = get_labels(graph)
+            graph = networkx.from_pandas_adjacency(group, create_using=networkx.DiGraph)
+            labels = get_labels(graph)
 
-        dataframe = pandas.Series(labels)\
-            .sort_index()\
-            .to_frame(column_names.prediction)\
-            .reset_index(names=column_names.id)
+            dataframe = pandas.Series(labels) \
+                .sort_index() \
+                .to_frame(prediction_column_name) \
+                .reset_index(names=column_names.id)
 
-        dataframe[column_names.moon] = key
-        dataframes.append(dataframe)
+            dataframe[column_names.moon] = key
+            dataframes.append(dataframe)
 
-    return pandas.concat(dataframes)
+        return pandas.concat(dataframes)
 
 
 def process_y(
     y_test: typing.Dict[str, pandas.DataFrame],
     column_names: api.ColumnNames,
 ):
-    dataframes: typing.List[pandas.DataFrame] = []
-    for key, y in y_test.items():
-        edges = y.set_index(PARENT_COLUMN_NAME).unstack().reset_index()
-        edges.columns = [TO_COLUMN_NAME, FROM_COLUMN_NAME, column_names.target]
+    # TODO support multiple target
+    for targe_column_names in column_names.targets.values():
+        target_column_name = targe_column_names.input
 
-        group = edges.pivot(
-            index=FROM_COLUMN_NAME,
-            columns=TO_COLUMN_NAME,
-            values=column_names.target
-        )
+        dataframes: typing.List[pandas.DataFrame] = []
+        for key, y in y_test.items():
+            edges = y.set_index(PARENT_COLUMN_NAME).unstack().reset_index()
+            edges.columns = [TO_COLUMN_NAME, FROM_COLUMN_NAME, target_column_name]
 
-        graph = networkx.from_pandas_adjacency(group, create_using=networkx.DiGraph)
-        labels = get_labels(graph)
+            group = edges.pivot(
+                index=FROM_COLUMN_NAME,
+                columns=TO_COLUMN_NAME,
+                values=target_column_name
+            )
 
-        dataframe = pandas.Series(labels)\
-            .sort_index()\
-            .to_frame(column_names.target)\
-            .reset_index(names=column_names.id)
+            graph = networkx.from_pandas_adjacency(group, create_using=networkx.DiGraph)
+            labels = get_labels(graph)
 
-        dataframe[column_names.moon] = key
-        dataframes.append(dataframe)
+            dataframe = pandas.Series(labels)\
+                .sort_index()\
+                .to_frame(target_column_name)\
+                .reset_index(names=column_names.id)
 
-    return pandas.concat(dataframes)
+            dataframe[column_names.moon] = key
+            dataframes.append(dataframe)
+
+        return pandas.concat(dataframes)
 
 
 def merge(
@@ -142,8 +150,6 @@ def merge(
     prediction: pandas.DataFrame,
     column_names: api.ColumnNames,
 ):
-    raise NotImplementedError()
-
     prediction = process_prediction(
         prediction,
         column_names,

--- a/crunch/scoring/_format/dag.py
+++ b/crunch/scoring/_format/dag.py
@@ -142,6 +142,8 @@ def merge(
     prediction: pandas.DataFrame,
     column_names: api.ColumnNames,
 ):
+    raise NotImplementedError()
+
     prediction = process_prediction(
         prediction,
         column_names,

--- a/crunch/scoring/_format/timeseries.py
+++ b/crunch/scoring/_format/timeseries.py
@@ -11,13 +11,13 @@ def merge(
     prediction = prediction[[
         column_names.moon,
         column_names.id,
-        column_names.prediction
+        *column_names.outputs
     ]]
 
     y_test = y_test[[
         column_names.moon,
         column_names.id,
-        column_names.target
+        *column_names.inputs
     ]]
 
     return pandas.merge(

--- a/crunch/scoring/scorers.py
+++ b/crunch/scoring/scorers.py
@@ -74,6 +74,14 @@ def precision(
     )
 
 
+def random(
+    group: pandas.DataFrame,
+    target_column_name: str,
+    prediction_column_name: str,
+) -> float:
+    return numpy.random.random_sample()
+
+
 def recall(
     group: pandas.DataFrame,
     target_column_name: str,
@@ -110,6 +118,7 @@ REGISTRY = {
     api.ScorerFunction.DOT_PRODUCT: dot_product,
     api.ScorerFunction.F1: fbeta_factory(beta=1),
     api.ScorerFunction.PRECISION: precision,
+    api.ScorerFunction.RANDOM: random,
     api.ScorerFunction.RECALL: recall,
     api.ScorerFunction.SPEARMAN: spearman,
 }

--- a/crunch/store.py
+++ b/crunch/store.py
@@ -18,5 +18,6 @@ def load_from_env():
     if not debug:
         debug = humanfriendly.coerce_boolean(os.getenv(constants.DEBUG_ENV_VAR))
 
-    web_base_url = os.getenv(constants.WEB_BASE_URL_ENV_VAR, constants.WEB_BASE_URL_DEFAULT)
-    api_base_url = os.getenv(constants.API_BASE_URL_ENV_VAR, constants.API_BASE_URL_DEFAULT)
+    if web_base_url is None:
+        web_base_url = os.getenv(constants.WEB_BASE_URL_ENV_VAR, constants.WEB_BASE_URL_DEFAULT)
+        api_base_url = os.getenv(constants.API_BASE_URL_ENV_VAR, constants.API_BASE_URL_DEFAULT)

--- a/crunch/vendor/datacrunch.py
+++ b/crunch/vendor/datacrunch.py
@@ -13,16 +13,15 @@ def orthogonalize(
     column_names: api.ColumnNames,
     **kwargs
 ):
-    prediction_column_name = column_names.prediction
-
     def process(group: pandas.DataFrame):
         date = group.name
 
-        group[prediction_column_name] = _gaussianizer(group[prediction_column_name])
-        group[prediction_column_name] = _orthogonalizer(group, orthogonalization_data[date], column_names.id, prediction_column_name)
-        # Based on orthogonalization_data, necessary to bring back to mean zero before L1-normalizing.
-        group[prediction_column_name] = _mean_zeroed(group[prediction_column_name])
-        group[prediction_column_name] = _l1_normalize(group[prediction_column_name])
+        for prediction_column_name in column_names.outputs:
+            group[prediction_column_name] = _gaussianizer(group[prediction_column_name])
+            group[prediction_column_name] = _orthogonalizer(group, orthogonalization_data[date], column_names.id, prediction_column_name)
+            # Based on orthogonalization_data, necessary to bring back to mean zero before L1-normalizing.
+            group[prediction_column_name] = _mean_zeroed(group[prediction_column_name])
+            group[prediction_column_name] = _l1_normalize(group[prediction_column_name])
 
         return group
 

--- a/tests/runner/test_columns.py
+++ b/tests/runner/test_columns.py
@@ -2,7 +2,7 @@ import collections
 import unittest
 
 from crunch.api import ColumnNames, TargetColumnNames
-from crunch.runner.runner import Columns
+from crunch.runner import Columns
 
 
 class ColumnsTest(unittest.TestCase):

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1,0 +1,77 @@
+import collections
+import unittest
+
+from crunch.api import ColumnNames, TargetColumnNames
+from crunch.runner.runner import Columns
+
+
+class ColumnsTest(unittest.TestCase):
+
+    def test_get_item(self):
+        columns = Columns(collections.OrderedDict(a="b"))
+
+        self.assertEqual("b", columns["a"])
+
+    def test_get_attr(self):
+        columns = Columns(collections.OrderedDict(a="b"))
+
+        self.assertEqual("b", columns.a)
+
+    def test_set_item(self):
+        columns = Columns(collections.OrderedDict(a="b"))
+
+        with self.assertRaises(AttributeError) as context:
+            columns["a"] = "c"
+
+        self.assertEqual("Cannot set key 'a' - object is immutable", str(context.exception))
+
+    def test_set_attr(self):
+        columns = Columns(collections.OrderedDict(a="b"))
+
+        with self.assertRaises(AttributeError) as context:
+            columns.a = "c"
+
+        self.assertEqual("Cannot set attribute 'a' - object is immutable", str(context.exception))
+
+    def test_iter(self):
+        columns = Columns(collections.OrderedDict(a="b", c="d"))
+
+        self.assertEqual(["b", "d"], list(columns))
+
+        iterator = iter(columns)
+        self.assertEqual("b", next(iterator))
+        self.assertEqual("d", next(iterator))
+        self.assertEqual(None, next(iterator, None))
+
+    def test_repr(self):
+        columns = Columns(collections.OrderedDict(a="b", c="d"))
+
+        self.assertEqual("{a: 'b', c: 'd'}", repr(columns))
+
+    def test_str(self):
+        columns = Columns(collections.OrderedDict(a="b", c="d"))
+
+        self.assertEqual("Columns({a: 'b', c: 'd'})", str(columns))
+
+    def test_from_model(self):
+        column_names = ColumnNames(
+            id=None,
+            moon=None,
+            targets=collections.OrderedDict(
+                a=TargetColumnNames("b", "c"),
+                d=TargetColumnNames("e", "f")
+            )
+        )
+
+        inputs, outputs = Columns.from_model(column_names)
+
+        self.assertEqual("{a: 'b', d: 'e'}", repr(inputs))
+        self.assertEqual("{a: 'c', d: 'f'}", repr(outputs))
+
+    def test_no_external_access(self):
+        columns = Columns(collections.OrderedDict(a="b"))
+
+        with self.assertRaises(AttributeError) as context:
+            columns._storage
+
+        self.assertEqual("'Columns' object has no attribute '_storage'", str(context.exception))


### PR DESCRIPTION
# 3.10.0

## Features

- api: add target model
- checker: support multiple target column
- scoring: support multiple target column
- scoring: add `RANDOM` scorer (for testing purposes)
- runner: add the `Columns` like to easily iterate over a dict-list-like object
- command/init: add (similar to git init)
- runner/cloud: support multiple target column
- cli: add `--staging` to directly target the staging environment

## Changes

- api: `ColumnNames` now have a `targets` property (replacing the old `target_column_name` and `prediction_column_name`)