### PR TITLE
fix(setup): wrong clone endpoint

### DIFF
--- a/crunch/__version__.py
+++ b/crunch/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'crunch-cli'
 __description__ = 'crunch-cli - CLI of the CrunchDAO Platform'
-__version__ = '3.14.0'
+__version__ = '3.14.1'
 __author__ = 'Enzo CACERES'
 __author_email__ = 'enzo.caceres@crunchdao.com'
 __url__ = 'https://github.com/crunchdao/crunch-cli'

--- a/crunch/api/client.py
+++ b/crunch/api/client.py
@@ -143,7 +143,10 @@ class EndpointClient(
             return self._result_sse(response, sse_handler, json)
 
         if json:
-            return response.json()
+            try:
+                return response.json()
+            except requests.exceptions.JSONDecodeError as json_error:
+                raise ValueError(f"could not parse json: `{response.text}`") from json_error
 
         if binary:
             return response.content

--- a/crunch/api/domain/project.py
+++ b/crunch/api/domain/project.py
@@ -108,7 +108,6 @@ class ProjectCollection(Collection):
             )
         )
 
-    # TODO Introduce an endpoint instead
     def list(
         self,
         user_identifier: typing.Union[int, str] = "@me",

--- a/crunch/api/domain/project.py
+++ b/crunch/api/domain/project.py
@@ -262,7 +262,7 @@ class ProjectEndpointMixin:
 
         return self._result(
             self.get(
-                f"/v3/competitions/{competition_identifier}/projects/{user_identifier}/{project_identifier}/clone",
+                f"/v4/competitions/{competition_identifier}/projects/{user_identifier}/{project_identifier}/clone",
                 params=params
             ),
             json=True

--- a/crunch/command/setup.py
+++ b/crunch/command/setup.py
@@ -26,7 +26,6 @@ def setup(
     _, project = api.Client.from_project()
 
     try:
-        print(project._attrs)
         urls = project.clone(
             submission_number=submission_number,
             include_model=not no_model,


### PR DESCRIPTION
# 3.14.1

## Features

- api/client: raise error if json could not be parsed

## Fixes

- api/project: use v4 endpoint for clone
- setup: remove debug print