### PR TITLE
fix(inline): fallback to `getattr(crunch, key)`

### DIFF
--- a/crunch/__version__.py
+++ b/crunch/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'crunch-cli'
 __description__ = 'crunch-cli - CLI of the CrunchDAO Platform'
-__version__ = '3.14.1'
+__version__ = '3.14.2'
 __author__ = 'Enzo CACERES'
 __author_email__ = 'enzo.caceres@crunchdao.com'
 __url__ = 'https://github.com/crunchdao/crunch-cli'

--- a/crunch/inline.py
+++ b/crunch/inline.py
@@ -5,7 +5,7 @@ import typing
 import click
 import pandas
 
-from . import api, command, constants, utils, orthogonalization, runner
+from . import api, command, constants, orthogonalization, runner, utils
 
 
 class _Inline:
@@ -16,9 +16,6 @@ class _Inline:
         self.has_gpu = has_gpu
 
         print(f"loaded inline runner with module: {module}")
-
-    def load_notebook(self, *args, **kwargs):
-        return load(*args, **kwargs)
 
     def load_data(self, **kwargs) -> typing.Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
         try:
@@ -105,6 +102,11 @@ class _Inline:
     @property
     def is_inside_runner(self):
         return runner.is_inside
+
+    def __getattr__(self, key):
+        import crunch
+
+        return getattr(crunch, key)
 
 
 def load(


### PR DESCRIPTION
# 3.14.2

## Features

- inline: fallback to `getattr(crunch, key)`