### PR TITLE
fix(runner/cloud-executor): call `reset_index()` after `copy()`

### DIFF
--- a/crunch/runner/cloud_executor.py
+++ b/crunch/runner/cloud_executor.py
@@ -323,7 +323,10 @@ class SandboxExecutor:
     def filter_train(self, dataframe: pandas.DataFrame):
         if self.competition_format == api.CompetitionFormat.TIMESERIES:
             # TODO Use split's key with (index(moon) - embargo)
-            return dataframe[dataframe[self.column_names.moon] < self.moon - self.embargo].reset_index()
+            dataframe = dataframe[dataframe[self.column_names.moon] < self.moon - self.embargo].copy()
+            dataframe.reset_index(inplace=True, drop=True)
+
+            return dataframe
 
         if self.competition_format == api.CompetitionFormat.DAG:
             dataframe: dict
@@ -344,7 +347,10 @@ class SandboxExecutor:
 
     def filter_test(self, dataframe: pandas.DataFrame):
         if self.competition_format == api.CompetitionFormat.TIMESERIES:
-            return dataframe[dataframe[self.column_names.moon] == self.moon].reset_index()
+            dataframe = dataframe[dataframe[self.column_names.moon] == self.moon].copy()
+            dataframe.reset_index(inplace=True, drop=True)
+
+            return dataframe
 
         if self.competition_format == api.CompetitionFormat.DAG:
             dataframe: dict

--- a/crunch/runner/cloud_executor.py
+++ b/crunch/runner/cloud_executor.py
@@ -323,7 +323,7 @@ class SandboxExecutor:
     def filter_train(self, dataframe: pandas.DataFrame):
         if self.competition_format == api.CompetitionFormat.TIMESERIES:
             # TODO Use split's key with (index(moon) - embargo)
-            return dataframe[dataframe[self.column_names.moon] < self.moon - self.embargo].copy()
+            return dataframe[dataframe[self.column_names.moon] < self.moon - self.embargo].reset_index()
 
         if self.competition_format == api.CompetitionFormat.DAG:
             dataframe: dict
@@ -344,7 +344,7 @@ class SandboxExecutor:
 
     def filter_test(self, dataframe: pandas.DataFrame):
         if self.competition_format == api.CompetitionFormat.TIMESERIES:
-            return dataframe[dataframe[self.column_names.moon] == self.moon].copy()
+            return dataframe[dataframe[self.column_names.moon] == self.moon].reset_index()
 
         if self.competition_format == api.CompetitionFormat.DAG:
             dataframe: dict


### PR DESCRIPTION
The local and cloud runners filtered the data differently. One was calling `reset_index()` (local) and the other was calling `copy()` (cloud). This messed up the indices when someone wanted to do a `pandas.concat' with X_test and a new dataframe.

## Fixes

- runner/cloud-executor: call `reset_index()` after `copy()`