### PR TITLE
perf(scoring/dag): optimize `get_labels`

### DIFF
--- a/crunch/scoring/_format/dag.py
+++ b/crunch/scoring/_format/dag.py
@@ -55,8 +55,8 @@ def get_labels(
     Output: list of tuple, with the edges as keys (excluding 'X' and 'Y'): (dataset_id, node, value)
     """
 
+    nodes = pivoted.columns.to_list()
     graph = networkx.from_pandas_adjacency(pivoted, create_using=networkx.DiGraph)
-    nodes = list(graph.nodes)
 
     if 'X' not in nodes:
         raise BadGraphError(f"X not in nodes for dataset `{key}`")
@@ -70,7 +70,7 @@ def get_labels(
     if not networkx.is_directed_acyclic_graph(graph):
         raise BadGraphError(f"not a directed acyclic graph for dataset `{key}`")
 
-    A = networkx.adjacency_matrix(graph).todense()
+    A = pivoted.values
 
     x_index = nodes.index('X')
     y_index = nodes.index('Y')


### PR DESCRIPTION
## Performance

- scoring/dag: optimize `get_labels` by not performing unnecessary operations and trusting the pivoted dataframe directly

## Benchmark

| Prediction ID | `get_labels` | Submission Processing | Solution Processing | Score |
| --- | --- | --- | --- | --- |
| 14145 | current | 00:16 at 571.59it/s | 00:17 at 577.95it/s | **0.3789**783772871458 |
| | optimized | 00:15 at 639.73it/s | 00:15 at 644.57it/s | **0.3789**783772871458 |
| | | | | |
| 14397 | current | 00:17 at 548.20it/s | 00:16 at 574.40it/s | **0.1926**8937435035088 |
| | optimized | 00:15 at 633.63it/s | 00:15 at 616.71it/ | **0.1926**8937435035088 |
| | | | | |
| 14400 | current | 00:38 at 443.13it/s | 00:23 at 373.96it/ | **0.4914**5823973035085 |
| | optimized | 00:17 at 467.09it/s | 00:19 at 588.69it/ | **0.4914**5823973035085 |
| | | | | |
| 14439 | current | 00:17 at 510.70it/s | 00:20 at 397.33it/ | **0.5087**069557397074 |
| | optimized | 00:16 at 644.69it/s | 00:15 at 640.14it/ | **0.5087**069557397074 |
| | | | | |
| 14502 | current | 00:16 at 567.16it/s | 00:20 at 569.40it/ | **0.4508**7919026732687 |
| | optimized | 00:15 at 508.91it/s | 00:15 at 592.65it/ | **0.4508**7919026732687 |
| | | | | |
| 14721 | current | 00:18 at 527.89it/s | 00:18 at 522.82it/ | **0.5086**765662451519 |
| | optimized | 00:16 at 589.54it/s | 00:19 at 529.64it/ | **0.5086**765662451519 |
| | | | | |
| 14792 | current | 00:19 at 517.12it/s | 00:18 at 524.55it/ | **0.5247**932503628641 |
| | optimized | 00:17 at 538.81it/s | 00:17 at 563.91it/ | **0.5247**932503628641 |
| | | | | |
| 14798 | current | 00:19 at 501.33it/s | 00:19 at 490.22it/ | **0.5352**476743966134 |
| | optimized | 00:16 at 562.16it/s | 00:19 at 576.06it/ | **0.5352**476743966134 |
| | | | | |
| 15011 | current | 00:18 at 502.00it/s | 00:20 at 448.60it/ | **0.5212**374326452135 |
| | optimized | 00:17 at 442.69it/s | 00:17 at 581.52it/ | **0.5212**374326452135 |
| | | | | |
| 15038 | current | 00:21 at 398.69it/s | 00:20 at 506.69it/ | **0.3786**833103166241 |
| | optimized | 00:18 at 410.46it/s | 00:17 at 567.88it/ | **0.3786**833103166241 |
| | | | | |
| 15326 | current | 00:19 at 517.59it/s | 00:19 at 499.54it/ | **0.3790**4704029680863 |
| | optimized | 00:17 at 551.86it/s | 00:17 at 548.81it/ | **0.3790**4704029680863 |