### PR TITLE
fix(push): use `importlib_metadata` instead of `pkg_resources` to find locally installed packages

### DIFF
--- a/crunch/command/push.py
+++ b/crunch/command/push.py
@@ -67,18 +67,10 @@ def push(
     dry: bool,
     export_path: str = None,
 ):
-    import pkg_resources
-
     client, project = api.Client.from_project()
     competition = project.competition
 
-    installed_packages_version = {}
-    if include_installed_packages_version:
-        installed_packages_version = {
-            package.project_name: package.version
-            for package in pkg_resources.working_set
-            if utils.is_valid_version(package.version)
-        }
+    installed_packages_version = utils.pip_freeze() if include_installed_packages_version else {}
 
     fds = []
 

--- a/crunch/utils.py
+++ b/crunch/utils.py
@@ -160,6 +160,28 @@ def to_unix_path(input: str):
         .replace("//", "/")
 
 
+def pip_freeze():
+    import importlib_metadata
+
+    working_set = {}
+
+    installed_packages = {
+        package
+        for packages in importlib_metadata.packages_distributions().values()
+        for package in packages
+    }
+
+    for package in installed_packages:
+        version = importlib_metadata.version(package)
+
+        if not is_valid_version(version):
+            continue
+
+        working_set[package] = version
+
+    return working_set
+
+
 def is_valid_version(input: str):
     import packaging.version
 
@@ -430,5 +452,5 @@ def split_at_nans(
 
         if start != end or keep_empty:
             parts.append(dataframe.iloc[start:end])
-    
+
     return parts

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -4,6 +4,7 @@ coloredlogs
 dataclasses_json
 gitignorefile
 humanfriendly
+importlib_metadata
 inflection
 inquirer
 joblib
@@ -21,3 +22,4 @@ scikit-learn
 scipy
 sseclient-py
 tqdm
+importlib_metadata

--- a/requirements/runner.txt
+++ b/requirements/runner.txt
@@ -4,6 +4,7 @@ click
 dataclasses_json
 
 humanfriendly
+
 inflection
 
 joblib

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from crunch.utils import cut_url
+from crunch.utils import cut_url, is_valid_version, pip_freeze
 
 
 class CutUrlTest(unittest.TestCase):
@@ -16,3 +16,16 @@ class CutUrlTest(unittest.TestCase):
     def test_keep_double(self):
         self.assertEqual("http:google.com//search//a", cut_url("http://google.com//search//a?q=hello"))
         self.assertEqual("https:google.com//search//a", cut_url("https://google.com//search//a?q=hello"))
+
+
+class PipTest(unittest.TestCase):
+
+    def test_is_valid_version(self):
+        self.assertTrue(is_valid_version("1.2.3"))
+        self.assertFalse(is_valid_version("a1"))
+
+    def test_pip_freeze(self):
+        working_set = pip_freeze()
+
+        self.assertTrue(len(working_set) != 0)
+        self.assertIn("crunch-cli", working_set)


### PR DESCRIPTION
## Fixes

- push: remove the use of `pkg_resources` as it is deprecated in Python 3.12