### PR TITLE
typos(competition): "spacial"

### DIFF
--- a/crunch/api/domain/competition.py
+++ b/crunch/api/domain/competition.py
@@ -11,7 +11,7 @@ class CompetitionFormat(enum.Enum):
     TIMESERIES = "TIMESERIES"
     DAG = "DAG"
     STREAM = "STREAM"
-    SPACIAL = "SPACIAL"
+    SPATIAL = "SPATIAL"
 
     def __repr__(self):
         return self.name


### PR DESCRIPTION
## Typos

- competition: change "spacial" to "spatial"