### PR TITLE
fix(custom/code-loader): use curl's user agent

### DIFF
--- a/crunch/custom/code_loader.py
+++ b/crunch/custom/code_loader.py
@@ -49,8 +49,10 @@ class GithubCodeLoader(CodeLoader):
         competition_name: str,
         repository=constants.COMPETITIONS_REPOSITORY,
         branch=constants.COMPETITIONS_BRANCH,
+        user_agent="curl/7.88.1"
     ):
         self._path = f"https://raw.githubusercontent.com/{repository}/refs/heads/{branch}/competitions/{competition_name}/scoring/scoring.py"
+        self._user_agent = user_agent
 
     @property
     def path(self):
@@ -58,7 +60,13 @@ class GithubCodeLoader(CodeLoader):
 
     @property
     def source(self):
-        response = requests.get(self._path)
+        response = requests.get(
+            self._path,
+            headers={
+                "User-Agent": self._user_agent
+            }
+        )
+
         response.raise_for_status()
         return response.text
 


### PR DESCRIPTION
GitHub requires a User-Agent header, but the [one from curl should be valid](https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api?apiVersion=2022-11-28#user-agent-required). ([source](https://stackoverflow.com/a/39912696/7292958))