### PR TITLE
chore(requirements): remove `spatialdata-plot`

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -19,6 +19,3 @@ requirements-parser>=0.11.0
 scikit-learn
 scipy
 tqdm
-
-# TODO Remove me once competition is over
-spatialdata-plot

--- a/requirements/runner.txt
+++ b/requirements/runner.txt
@@ -7,7 +7,7 @@ joblib
 
 
 pandas
-
+psutil
 pyarrow
 
 python-dotenv

--- a/requirements/runner.txt
+++ b/requirements/runner.txt
@@ -19,6 +19,3 @@ requests-toolbelt
 
 
 tqdm
-
-# TODO Remove me once competition is over
-spatialdata-plot


### PR DESCRIPTION
The broad competitions are over, so the package is not necessary anymore.

And we are going into a per-competition configuration via the [competitions repository](https://github.com/crunchdao/competitions).
We will soon store a `requirements.txt` in it too.